### PR TITLE
Add scratchpad

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -232,6 +232,23 @@
       background-color: #f2f2f2;
     }
 
+    #scratchpadDialog {
+      position: absolute;
+      z-index: 100;
+      display: inline-block;
+      text-align: start;
+      background-color: white;
+      border: 1px solid black;
+      padding: 1em;
+    }
+
+    #scratchpadDialog.hidden {
+      display: none;
+    }
+
+    #scratchpadDialog textarea {
+      margin-top: 0.5em;
+    }
   </style>
 
   <style type="text/css" media="print">
@@ -287,6 +304,15 @@
         <input id="BPrevGlyph" type="button" value="&#x2191;" title="show prev codepoint with glyph(k)">
         <input id="BNext" type="button" value="&#x2192;" title="show next codepoint(l)">
         <input id="BShowPrev" type="button" title="show (p)rev glyph" value="Show Prev">
+        <input id="BShowScratchpad" type="button" title="toggle Scratchpad" value="Scratchpad">
+        <div id="scratchpadDialog" class="hidden">
+          <div class="controls">
+            <input type="button" value="insert" title="insert current glyph"></input>
+            <label id="scrachpadGlyphSizeSliderContainer"><input id="scrachpadGlyphSizeSlider"
+            type="range" min="10" max="200" value="100"><span><span></label>
+          </div>
+          <textarea class="smufl"></textarea>
+        </div>
         <select id="rangeSelect" title="(r)anges"></select>
       </div>
       <div id="smuflGlyphCanvasContainer">

--- a/docs/app.html
+++ b/docs/app.html
@@ -299,7 +299,7 @@
         <label title="glyph bounding box"><input id="smuflRenderGlyphOptionsBbox" type="checkbox" checked />bbox<span
             class="val"></span></label>
         <label id="smuflRenderGlyphOptionsGlyphSizeContainer">glyph size: <input id="smuflRenderGlyphOptionsGlyphSize"
-            type="range" min="150" max="1000" value="200"><span><span></label>
+            type="range" min="30" max="1000" value="200"><span><span></label>
       </div>
       <div id="smuflGlyphHints">
         <label title="The exact position at which the bottom left-hand (south-west) corner of an angled upward-pointing stem connecting the left-hand side of a notehead to a vertical stem to its right should start, relative to the glyph origin, expressed as Cartesian coordinates in staff spaces."><input

--- a/docs/viewer.js
+++ b/docs/viewer.js
@@ -219,6 +219,36 @@ class SMuFLFontViewer {
       renderGlyph(currentGlyphData);
     });
 
+    const $scratchpadDialog = $('#scratchpadDialog');
+    $('#BShowScratchpad').on('click', function() {
+      $scratchpadDialog.toggleClass('hidden');
+    });
+
+    const $scratchpadDialogTextarea = $('#scratchpadDialog textarea');
+    const $scrachpadGlyphSizeSlider = $('#scrachpadGlyphSizeSlider');
+
+    $scrachpadGlyphSizeSlider.on('input', function() {
+      this.nextElementSibling.textContent = this.value;
+      const nPx = Number(this.value);
+      $scratchpadDialogTextarea.css('font-size', nPx + 'px');
+
+      // FIXME: too large clientRect by Petaluma and Bravura, limit textarea size
+      $scratchpadDialogTextarea.css('height', (nPx * 3) + 'px');
+      $scratchpadDialogTextarea.css('width', (nPx * 5) + 'px');
+    });
+
+    $scrachpadGlyphSizeSlider.trigger('input');
+
+    const $scratchpadDialogInsertButton = $('#scratchpadDialog .controls input[type="button"]');
+    $scratchpadDialogInsertButton.on('click', function() {
+      const elm = $scratchpadDialogTextarea[0];
+      const value = $scratchpadDialogTextarea.val();
+      const head = value.slice(0,elm.selectionStart);
+      const tail = value.slice(elm.selectionEnd);
+      const newValue = head + String.fromCodePoint(currentGlyphData.codepoint) + tail;
+      $scratchpadDialogTextarea.val(newValue);
+    });
+
     $('#smuflRenderGlyphOptions input').on('change', function(ev) {
       if (ev.target._on3StateChange) {
         ev.target._on3StateChange();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59550999/86561056-aefe6d80-bf9a-11ea-8ace-6736f5e5b325.png)

- toggle scratchpad ui(textarea element) by `Scrachpad` button
  - insert current glyph to Scrachpad by `insert` button.
