### PR TITLE
Fix glyphs with alternates list with no optional glyphs

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -104,8 +104,12 @@
       line-height: 1.5em;
     }
 
-    span.optionalGlyph {
+    span.optionalGlyph, span.unknownOptionalGlyph {
       background-color: eef9ee;
+    }
+
+    span.unknownOptionalGlyph {
+      text-decoration: line-through;
     }
 
     span.currentGlyph {

--- a/docs/js/smuflutils.js
+++ b/docs/js/smuflutils.js
@@ -241,8 +241,11 @@ class SMuFLMetadata {
   glyphname2uCodepoint(glyphname, options = {}) {
     let item =  this.data.glyphnames[glyphname];
     if (!item && options.searchOptional) {
-      item = this.fontMetadata().optionalGlyphs[glyphname];
+      item = (this.fontMetadata().optionalGlyphs || {})[glyphname];
       options.isOptionalGlyph = item !== undefined;
+
+      // glyphname with no optionalGlyphs entry.
+      options.isUnknownOptionalGlyph = item === undefined;
     }
     return ((item || {}).codepoint);
   }

--- a/docs/viewer.js
+++ b/docs/viewer.js
@@ -615,14 +615,6 @@ class SMuFLFontViewer {
         target._on3StateChange();
       }
 
-      if (rosgCpSelect) {
-        if (smuflGlyphHints_repatOffset3StateBoxElm._3state == 2) {
-          rosgCpSelect.$codepointSelect_selectize.$control.show();
-        } else {
-          rosgCpSelect.$codepointSelect_selectize.$control.hide();
-        }
-      }
-
       //console.log(this);
       renderGlyph(currentGlyphData);
     });
@@ -1654,6 +1646,18 @@ class SMuFLFontViewer {
 
       ctx.fillStyle = '#444444cc';
       _renderGlyph(glyphData, x, y, fontSize);
+
+      if (rosgCpSelect) {
+        if ($(smuflGlyphHints_repatOffset3StateBoxElm).parent().is(':hidden')) {
+          rosgCpSelect.$codepointSelect_selectize.$control.hide();
+        } else {
+          if (smuflGlyphHints_repatOffset3StateBoxElm._3state == 2) {
+            rosgCpSelect.$codepointSelect_selectize.$control.show();
+          } else {
+            rosgCpSelect.$codepointSelect_selectize.$control.hide();
+          }
+        }
+      }
 
       if ($smuflGlyphHints_repatOffset3StateBox.prop('checked')) {
         ctx.save();

--- a/docs/viewer.js
+++ b/docs/viewer.js
@@ -571,6 +571,9 @@ class SMuFLFontViewer {
       if (option.isOptionalGlyph) {
         $t.addClass('optionalGlyph');
       }
+      if (option.isUnknownOptionalGlyph) {
+        $t.addClass('unknownOptionalGlyph');
+      }
       if (currentGlyphName === glyphname) {
         $t.addClass('currentGlyph');
       }
@@ -1128,7 +1131,7 @@ class SMuFLFontViewer {
           _$c_appendText($alternatesInfo, 'codepoint: ');
           appendCodepoint($alternatesInfo, v.codepoint);
           _$c_appendText($alternatesInfo, `, name: `);
-          appendGlyphname($alternatesInfo, v.name, glyphname);
+          appendGlyphname($alternatesInfo, v.name, glyphname, v.codepoint);
           _$c_appendText($alternatesInfo, `\n`);
         });
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59550999/111930598-a932c300-8afc-11eb-8664-4aa1a87946ef.png)

- Since, Leland has no `optionalGlyphs` prop,  it does not support `alternates` view.
- Draw a line-through for the glyphname to indicate that there is no `optionalGlyphs` entry.
---
- hide repeatOffset sample glyph select list if glyph has no repeatOffset prop.