### PR TITLE
Feature/add launch settings 1

### DIFF
--- a/docs/app.html
+++ b/docs/app.html
@@ -14,8 +14,8 @@
     */
 
     .smufl,
-    .codepointSelect_selectize.selectize-control .selectize-input .item {
-      font-family: sans-serif, SMuFLFont;
+    .selectize-control .custom-item .cpStr {
+      font-family: SMuFLFont, sans-serif;
     }
 
     #contentContainer .smufl {

--- a/docs/app.html
+++ b/docs/app.html
@@ -14,8 +14,8 @@
     */
 
     .smufl,
-    .selectize-control {
-      font-family: SMuFLFont, sans-serif;
+    .codepointSelect_selectize.selectize-control .selectize-input .item {
+      font-family: sans-serif, SMuFLFont;
     }
 
     #contentContainer .smufl {

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -352,6 +352,15 @@
         ));
 
 
+
+      addDemolistSeparetorItem();
+      addDemolistItem('diedeno/OS-SMuFL-Fonts/:Chardonnay + w3c/smufl',
+        _createDemolistOptions(
+          'https://raw.githubusercontent.com/diedeno/OS-SMuFL-Fonts/refs/heads/main/Chardonnay',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          '/Chardonnay.otf', '/chardonnay_metadata.json'
+        ));
+
       //////////////////////////////////////////////////////////////////////
       var evt = new Event("change", { "bubbles": true, "cancelable": true });
       demolistElm.dispatchEvent(evt);

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -361,6 +361,15 @@
           '/Chardonnay.otf', '/chardonnay_metadata.json'
         ));
 
+      /*
+      addDemolistSeparetorItem();
+      addDemolistItem('brilliantribbon/reallyfake + w3c/smufl',
+        _createDemolistOptions(
+          'https://raw.githubusercontent.com/brilliantribbon/reallyfake/refs/heads/main/ReallyFake',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          '/ReallyFake.otf', '/metadata.json'
+        ));
+      */
       //////////////////////////////////////////////////////////////////////
       var evt = new Event("change", { "bubbles": true, "cancelable": true });
       demolistElm.dispatchEvent(evt);

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -334,7 +334,15 @@
           'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
           '/Golden Age.otf', '/Golden Age.json'
         ));
+      addDemolistSeparetorItem();
+      addDemolistItem('eNote-GmbH/Legato + w3c/smufl',
+        _createDemolistOptions(
+          'https://raw.githubusercontent.com/eNote-GmbH/Legato/refs/heads/main',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          '/Legato.otf', '/legato_metadata.json'
+        ));
 
+      //////////////////////////////////////////////////////////////////////
       var evt = new Event("change", { "bubbles": true, "cancelable": true });
       demolistElm.dispatchEvent(evt);
     })();

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -138,6 +138,11 @@
         demolistElm.appendChild(optionElm);
       }
 
+      function addDemolistSeparetorItem() {
+        var optionElm = document.createElement('hr');
+        demolistElm.appendChild(optionElm);
+      }
+
       function _createDemolistOptions(lFontBasePath, lMetadataBasePath, optFontPath, optFontMetadataPath, settings) {
         return {
           fontUrl: lFontBasePath + optFontPath,
@@ -174,6 +179,8 @@
         addDemolistItem('local BravuraText(debug)',
           _create_demo_bravura_options('BravuraText'));
 
+        addDemolistSeparetorItem();
+
         function _create_demo_petaluma_options(woff) {
           return _createDemolistOptions(
             './packages/petaluma/redist',
@@ -203,6 +210,8 @@
       addDemolistItem('steinbergmedia/bravura/master(BravuraText) + w3c/smufl',
         _create_bravura_options('BravuraText'));
 
+      addDemolistSeparetorItem();
+
       function _create_petaluma_options(woff) {
         return _createDemolistOptions(
           'https://raw.githubusercontent.com/steinbergmedia/petaluma/master/redist',
@@ -216,6 +225,8 @@
         _create_petaluma_options('Petaluma'));
       addDemolistItem('steinbergmedia/petaluma/master(PetalumaText) + w3c/smufl',
         _create_petaluma_options('PetalumaText'));
+
+      addDemolistSeparetorItem();
 
       function _create_Leland_options(otf, metadata) {
         return _createDemolistOptions(
@@ -231,8 +242,41 @@
       addDemolistItem('MuseScoreFonts/Leland/main(LelandText) + w3c/smufl',
         _create_Leland_options('LelandText', 'leland_metadata'));
 
-      var evt = new Event("change", { "bubbles": true, "cancelable": true });
-      demolistElm.dispatchEvent(evt);
+      addDemolistSeparetorItem();
+      function _create_Sebastian_options() {
+        return _createDemolistOptions(
+          'https://raw.githubusercontent.com/fkretlow/sebastian/refs/heads/master/fonts',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          '/Sebastian.otf', '/Sebastian.json'
+        );
+      }
+
+      addDemolistItem('fkretlow/sebastian + w3c/smufl',
+        _create_Sebastian_options());
+
+      function _create_Leipzig_options() {
+        return _createDemolistOptions(
+          'https://raw.githubusercontent.com/rism-digital/verovio/refs/heads/master/fonts/Leipzig',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          '/Leipzig.woff2', '/leipzig_metadata.json'
+        );
+      }
+
+      addDemolistSeparetorItem();
+
+      addDemolistItem('rism-digital/verovio:fonts/Leipzig + w3c/smufl',
+        _create_Leipzig_options());
+
+      function _create_Gootville_options() {
+        return _createDemolistOptions(
+          'https://raw.githubusercontent.com/rism-digital/verovio/refs/heads/master/fonts/Gootville',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          '/Gootville.otf', '/gootville_metadata.json'
+        );
+      }
+
+      addDemolistItem('rism-digital/verovio:fonts/Gootville + w3c/smufl',
+        _create_Gootville_options());
     })();
   </script>
 </body>

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -245,7 +245,7 @@
       addDemolistSeparetorItem();
       function _create_MuseJazz_options(otf, metadata) {
         return _createDemolistOptions(
-          'https://raw.githubusercontent.com/musescore/MuseScore/refs/heads/master/fonts/musejazz/',
+          'https://raw.githubusercontent.com/musescore/MuseScore/refs/heads/master/fonts/musejazz',
           'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
           `/${otf}.otf`, `/${metadata}.json`
         );
@@ -326,6 +326,14 @@
 
       addDemolistItem('rism-digital/verovio:fonts/Gootville + w3c/smufl',
         _create_Gootville_options());
+
+      addDemolistSeparetorItem();
+      addDemolistItem('benwiggy/GoldenAge + w3c/smufl',
+        _createDemolistOptions(
+          'https://raw.githubusercontent.com/benwiggy/GoldenAge/refs/heads/main/fonts',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          '/Golden Age.otf', '/Golden Age.json'
+        ));
 
       var evt = new Event("change", { "bubbles": true, "cancelable": true });
       demolistElm.dispatchEvent(evt);

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -326,6 +326,9 @@
 
       addDemolistItem('rism-digital/verovio:fonts/Gootville + w3c/smufl',
         _create_Gootville_options());
+
+      var evt = new Event("change", { "bubbles": true, "cancelable": true });
+      demolistElm.dispatchEvent(evt);
     })();
   </script>
 </body>

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -342,6 +342,16 @@
           '/Legato.otf', '/legato_metadata.json'
         ));
 
+
+      addDemolistSeparetorItem();
+      addDemolistItem('mikkopatama/eugenefont + w3c/smufl',
+        _createDemolistOptions(
+          'https://raw.githubusercontent.com/mikkopatama/eugenefont/refs/heads/main',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          '/Eugene.otf', '/Eugene.json'
+        ));
+
+
       //////////////////////////////////////////////////////////////////////
       var evt = new Event("change", { "bubbles": true, "cancelable": true });
       demolistElm.dispatchEvent(evt);

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -239,8 +239,10 @@
       addDemolistItem('MuseScoreFonts/Leland/main(Leland) + w3c/smufl',
         _create_Leland_options('Leland', 'leland_metadata'));
 
+      /*
       addDemolistItem('MuseScoreFonts/Leland/main(LelandText) + w3c/smufl',
         _create_Leland_options('LelandText', 'leland_metadata'));
+      */
 
       addDemolistSeparetorItem();
       function _create_MuseJazz_options(otf, metadata) {

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -258,6 +258,42 @@
         _create_MuseJazz_options('MuseJazzText', 'metadata'));
 
       addDemolistSeparetorItem();
+
+      function _create_FinaleMaestoro_options(otf, metadata) {
+        return _createDemolistOptions(
+          'https://raw.githubusercontent.com/musescore/MuseScore/refs/heads/main/fonts/finalemaestro',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          `/${otf}.otf`, `/${metadata}.json`
+        );
+      }
+
+      addDemolistItem('MuseScoreFonts/FinaleMaestro/main(FinaleMaestro) + w3c/smufl',
+        _create_FinaleMaestoro_options('FinaleMaestro', 'FinaleMaestro'));
+
+      /*
+      addDemolistItem('MuseScoreFonts/FinaleMaestro/main(FinaleMaestroText) + w3c/smufl',
+      _create_FinaleMaestoro_options('FinaleMaestroText-Regular', 'Finale Maestro Text'));
+      */
+      addDemolistSeparetorItem();
+
+      function _create_FinaleBroadway_options(otf, metadata) {
+        return _createDemolistOptions(
+          'https://raw.githubusercontent.com/musescore/MuseScore/refs/heads/main/fonts/finalebroadway',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          `/${otf}.otf`, `/${metadata}.json`
+        );
+      }
+
+      addDemolistItem('MuseScoreFonts/FinaleBroadway/main(FinaleBroadway) + w3c/smufl',
+        _create_FinaleBroadway_options('FinaleBroadway', 'FinaleBroadway'));
+
+      /*
+      addDemolistItem('MuseScoreFonts/FinaleBroadway/main(FinaleBroadwayText) + w3c/smufl',
+        _create_FinaleBroadway_options('FinaleBroadwayText', 'Finale Broadway Text'));
+      */
+      addDemolistSeparetorItem();
+
+
       function _create_Sebastian_options() {
         return _createDemolistOptions(
           'https://raw.githubusercontent.com/fkretlow/sebastian/refs/heads/master/fonts',
@@ -269,6 +305,7 @@
       addDemolistItem('fkretlow/sebastian + w3c/smufl',
         _create_Sebastian_options());
 
+      addDemolistSeparetorItem();
       function _create_Leipzig_options() {
         return _createDemolistOptions(
           'https://raw.githubusercontent.com/rism-digital/verovio/refs/heads/master/fonts/Leipzig',
@@ -276,9 +313,6 @@
           '/Leipzig.woff2', '/leipzig_metadata.json'
         );
       }
-
-      addDemolistSeparetorItem();
-
       addDemolistItem('rism-digital/verovio:fonts/Leipzig + w3c/smufl',
         _create_Leipzig_options());
 

--- a/docs/app_index.html
+++ b/docs/app_index.html
@@ -243,6 +243,21 @@
         _create_Leland_options('LelandText', 'leland_metadata'));
 
       addDemolistSeparetorItem();
+      function _create_MuseJazz_options(otf, metadata) {
+        return _createDemolistOptions(
+          'https://raw.githubusercontent.com/musescore/MuseScore/refs/heads/master/fonts/musejazz/',
+          'https://raw.githubusercontent.com/w3c/smufl/gh-pages/metadata',
+          `/${otf}.otf`, `/${metadata}.json`
+        );
+      }
+
+      addDemolistItem('MuseScoreFonts/MuseJazz/main(MuseJazz) + w3c/smufl',
+        _create_MuseJazz_options('MuseJazz', 'metadata'));
+
+      addDemolistItem('MuseScoreFonts/MuseJazz/main(MuseJazzText) + w3c/smufl',
+        _create_MuseJazz_options('MuseJazzText', 'metadata'));
+
+      addDemolistSeparetorItem();
       function _create_Sebastian_options() {
         return _createDemolistOptions(
           'https://raw.githubusercontent.com/fkretlow/sebastian/refs/heads/master/fonts',

--- a/docs/viewer.js
+++ b/docs/viewer.js
@@ -133,7 +133,7 @@ class SMuFLFontViewer {
 
       const smuflFontFace = new FontFace(
         "SMuFLFont",
-        `url(${fontFace.fontUrl})`
+        `url(${encodeURI(fontFace.fontUrl)})`
       );
 
       smuflFontFace

--- a/docs/viewer.js
+++ b/docs/viewer.js
@@ -236,6 +236,7 @@ class SMuFLFontViewer {
           });
 
           const $codepointSelect_selectize = $codepointSelect[0].selectize;
+          $codepointSelect_selectize.$wrapper.addClass("codepointSelect_selectize");
           $codepointSelect_selectize.onType = function (str, keepOptions) {
             str = str.toUpperCase();
             if (str.match(/^[A-F0-9]+$/)) {
@@ -2785,7 +2786,7 @@ class SMuFLFontViewer {
         // eslint-disable-next-line no-undef
         const tGlyph =
           smuFLFontViewer.sMuFLMetadata.getFontInfo().glyphsByUCodepoint[
-            uCodepoint
+          uCodepoint
           ];
         if (tGlyph && tGlyph.isOptionalGlyph) {
           tRange = {

--- a/docs/viewer.js
+++ b/docs/viewer.js
@@ -145,9 +145,8 @@ class SMuFLFontViewer {
           if (fontUrlItems.length < 1) {
             fontUrlItems = ["?"];
           }
-          document.title = `${fontUrlItems[fontUrlItems.length - 1]}: ${
-            document.title
-          }`;
+          document.title = `${fontUrlItems[fontUrlItems.length - 1]}: ${document.title
+            }`;
           window.setTimeout(function () {
             that._handle_onResourceReady("smuflFontFace");
           });
@@ -182,12 +181,8 @@ class SMuFLFontViewer {
           soptions.push({
             series: "glyphnames",
             value: cp,
-            name:
-              cp +
-              ": " +
-              gname +
-              ": " +
-              String.fromCodePoint(getCodepointNumber(cp)),
+            gname,
+            cpStr: String.fromCodePoint(getCodepointNumber(cp)),
           });
         });
 
@@ -204,8 +199,16 @@ class SMuFLFontViewer {
               gname +
               ": " +
               String.fromCodePoint(getCodepointNumber(cp)),
+            gname,
+            cpStr: String.fromCodePoint(getCodepointNumber(cp)),
           });
         });
+
+        function renderCustomItem(data, escape) {
+          return '<div class="custom-item">' +
+            `${data.value}:${data.gname}:<span class="cpStr">${data.cpStr}</span>` +
+            '</div>';
+        }
 
         const initCpSelect = ($codepointSelect, onChangeCB, onBlurCB) => {
           $codepointSelect.selectize({
@@ -231,8 +234,16 @@ class SMuFLFontViewer {
             onBlur: function () {
               onBlurCB($codepointSelect_selectize);
             },
-            //openOnFocus: false,
-            //plugins: ['optgroup_columns']
+            render: {
+              //openOnFocus: false,
+              //plugins: ['optgroup_columns']
+              item: function (data, escape) {
+                return renderCustomItem(data, escape);
+              },
+              option: function (data, escape) {
+                return renderCustomItem(data, escape);
+              },
+            }
           });
 
           const $codepointSelect_selectize = $codepointSelect[0].selectize;
@@ -268,6 +279,8 @@ class SMuFLFontViewer {
               series: "codepoint",
               value: cp,
               name: cp + ": " + String.fromCodePoint(getCodepointNumber(cp)),
+              gname: '?',
+              cpStr: String.fromCodePoint(getCodepointNumber(cp)),
             };
             $codepointSelect_selectize.addOption(cpData);
             return cpData;
@@ -669,12 +682,12 @@ class SMuFLFontViewer {
     function _resetScPosition() {
       $("#smuflGlyphCanvasContainer").scrollTop(
         $("#smuflGlyphCanvasContainer").prop("scrollHeight") * 0.5 -
-          $("#smuflGlyphCanvasContainer").innerHeight() * 0.5
+        $("#smuflGlyphCanvasContainer").innerHeight() * 0.5
       );
 
       $("#smuflGlyphCanvasContainer").scrollLeft(
         $("#smuflGlyphCanvasContainer").prop("scrollWidth") * 0.5 -
-          $("#smuflGlyphCanvasContainer").width() * 0.5
+        $("#smuflGlyphCanvasContainer").width() * 0.5
       );
     }
 
@@ -909,8 +922,7 @@ class SMuFLFontViewer {
         ? `<span class="uCodepoint">(${uCodepoint})</span> `
         : "";
       const $t = $(
-        `${$uCodepoint}<span class="smuflGlyphname">${
-          glyphname || "?"
+        `${$uCodepoint}<span class="smuflGlyphname">${glyphname || "?"
         }:<span class="smufl">${charStr}</span></span>`
       );
       if (option.isOptionalGlyph) {
@@ -1351,7 +1363,7 @@ class SMuFLFontViewer {
                 ev.preventDefault();
                 $ssOptionsGlyphSize.val(
                   Number($ssOptionsGlyphSize.val()) -
-                    (ev.originalEvent.deltaY < 0 ? -1 : 1) * 20
+                  (ev.originalEvent.deltaY < 0 ? -1 : 1) * 20
                 );
                 $ssOptionsGlyphSize.trigger("input");
               });
@@ -1639,7 +1651,7 @@ class SMuFLFontViewer {
             "class",
             sMuFLMetadata.getFontInfo().computedClasses.classes,
             //addItemFunc
-            (/*$itemContainer, item*/) => {},
+            (/*$itemContainer, item*/) => { },
             // getGlyphsFunc
             (item) => {
               return item;


### PR DESCRIPTION
Added new items to the launch settings list. Now supports the following launch settings:

- steinbergmedia/bravura/master + w3c/smufl
- steinbergmedia/bravura/master(BravuraText) + w3c/smufl
- steinbergmedia/petaluma/master + w3c/smufl
- steinbergmedia/petaluma/master(PetalumaText) + w3c/smufl
- MuseScoreFonts/Leland/main(Leland) + w3c/smufl
- MuseScoreFonts/Leland/main(LelandText) + w3c/smufl
- MuseScoreFonts/MuseJazz/main(MuseJazz) + w3c/smufl
- MuseScoreFonts/MuseJazz/main(MuseJazzText) + w3c/smufl
- MuseScoreFonts/FinaleMaestro/main(FinaleMaestro) + w3c/smufl
- MuseScoreFonts/FinaleMaestro/main(FinaleMaestroText) + w3c/smufl
- MuseScoreFonts/FinaleBroadway/main(FinaleBroadway) + w3c/smufl
- MuseScoreFonts/FinaleBroadway/main(FinaleBroadwayText) + w3c/smufl
- fkretlow/sebastian + w3c/smufl
- rism-digital/verovio:fonts/Leipzig + w3c/smufl
- rism-digital/verovio:fonts/Gootville + w3c/smufl
- benwiggy/GoldenAge + w3c/smufl
- eNote-GmbH/Legato + w3c/smufl
- mikkopatama/eugenefont + w3c/smufl
- diedeno/OS-SMuFL-Fonts/:Chardonnay + w3c/smufl
- ~~brilliantribbon/reallyfake + w3c/smufl~~
